### PR TITLE
(DAS-11) - [DB] Configure PostgreSQL and Create Base User Entity

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,4 +6,4 @@ services:
       - 'POSTGRES_PASSWORD=secret'
       - 'POSTGRES_USER=myuser'
     ports:
-      - '5432'
+      - '5432:5432'

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/dashsoft/identity/model/User.java
+++ b/src/main/java/net/dashsoft/identity/model/User.java
@@ -1,0 +1,92 @@
+package net.dashsoft.identity.model;
+
+import jakarta.persistence.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/net/dashsoft/identity/repository/UserRepository.java
+++ b/src/main/java/net/dashsoft/identity/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package net.dashsoft.identity.repository;
+
+import net.dashsoft.identity.model.User;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface UserRepository extends Repository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,0 @@
-spring:
-  application:
-    name: IdentityCore
-
-server:
-  port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: IdentityCore
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/mydatabase}
+    username: ${DB_USERNAME:myuser}
+    password: ${DB_PASSWORD:secret}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: ${SHOW_SQL:false}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+server:
+  port: 8080


### PR DESCRIPTION
This pull request introduces several changes to integrate a PostgreSQL database with a Spring Boot application and establish foundational components for user management. The most important changes include updates to the application configuration, new dependencies for Spring Data JPA, and the addition of model and repository classes for user data.

### Database Integration and Configuration:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL9-R9): Updated the PostgreSQL service to expose port `5432` for external connections by using the `5432:5432` format.
* [`src/main/resources/application.yml`](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR1-R22): Added configuration for the PostgreSQL datasource, including connection details (`url`, `username`, `password`), Hibernate properties (`ddl-auto`, `dialect`), and application/server settings. This replaces the removed `application.yaml` file. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR1-R22) [[2]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061L1-L6)

### Dependencies:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R86-R89): Added the `spring-boot-starter-data-jpa` dependency to enable JPA support for database interactions.

### User Management:

* [`src/main/java/net/dashsoft/identity/model/User.java`](diffhunk://#diff-2d3af40bb56a7bd551931ae575e3a6d4ee9da294234f2c636531cff4720c953dR1-R102): Introduced a `User` entity class annotated with JPA annotations (`@Entity`, `@Table`, etc.), including fields for user attributes (`email`, `password`, `firstName`, `lastName`, etc.), lifecycle callbacks (`@PrePersist`, `@PreUpdate`), and getter/setter methods.
* [`src/main/java/net/dashsoft/identity/repository/UserRepository.java`](diffhunk://#diff-bea5dafc085e98f754b2ed7a395026a0e90f64d8da42d2dfa21ca821eca717f2R1-R10): Added a `UserRepository` interface extending Spring Data's `Repository`, with a method to find users by email.